### PR TITLE
Tolerate absent/empty env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 [Unreleased]: https://github.com/JakeWharton/qbt-orphaned-downloads/compare/2.0.2...HEAD
 
+### Fixed
+
+ * Do not crash if `DEBUG` or `QBT_IGNORE_TAGS` env vars are not specified.
+
 
 ## [2.0.2] - 2024-12-27
 [2.0.2]: https://github.com/JakeWharton/qbt-orphaned-downloads/releases/tag/2.0.2

--- a/app/sync.py
+++ b/app/sync.py
@@ -2,7 +2,7 @@ import os
 from qbittorrentapi import Client, TorrentStates
 from logic import diff_tags
 
-DEBUG = os.environ['DEBUG'] == 'true'
+DEBUG = os.environ.get('DEBUG') == 'true'
 
 DOWNLOADS_PATH = "/downloads"
 INELIGIBLE_STATES = {
@@ -38,7 +38,7 @@ TAG_UNLINKED: str = os.environ['QBT_TAG_UNLINKED']
 TAG_LINKED: str = os.environ['QBT_TAG_LINKED']
 TAG_ORPHANED: str = os.environ['QBT_TAG_ORPHANED']
 ALL_TAG_SET: set[str] = {TAG_UNLINKED, TAG_LINKED, TAG_ORPHANED}
-IGNORE_TAG_SET: set[str] = set(filter(None, os.environ['QBT_IGNORE_TAGS'].split(',')))
+IGNORE_TAG_SET: set[str] = set(filter(None, os.environ.get('QBT_IGNORE_TAGS', default='').split(',')))
 SINGLE_TAG_MODE: bool = os.environ['QBT_SINGLE_TAG'] == 'true'
 DELETE_ORPHANS: str = os.environ['QBT_DELETE_ORPHANS']
 HOST = os.environ['QBT_HOST']


### PR DESCRIPTION
This used to work fine, as we specify an empty value by default in the `Dockerfile`. Something in the 2.x upgrade broke this (Alpine/S6/Python/VirtualEnv), so we simply become more tolerant to their absence.